### PR TITLE
Add blog category to settings

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -81,7 +81,8 @@ class Plugin extends PluginBase
                 'description' => self::LOCALIZATION_KEY . 'settings.description',
                 'icon'        => self::DEFAULT_ICON,
                 'class'       => Settings::class,
-                'order'       => 100
+                'order'       => 800,
+                'category'    => 'rainlab.blog::lang.blog.menu_label'
             ]
         ];
     }


### PR DESCRIPTION

Changes proposed in this pull request:

- This adds the blogtimetoread settings to the Blog group

@GinoPane
![](https://cl.ly/7dfcf40a2953/%255B741aae999ed0b034df27f1bc3c8f94c1%255D_Image%2525202019-09-05%252520at%25252011.40.02%252520PM.png)
![](https://cl.ly/6df6dbfcb446/%255B28a9fa75c25e977f7bb8fa38808c3a3f%255D_Image%2525202019-09-05%252520at%25252011.40.25%252520PM.png)